### PR TITLE
Migrating from React.PropTypes

### DIFF
--- a/lib/SwRefreshListView.android.js
+++ b/lib/SwRefreshListView.android.js
@@ -2,7 +2,8 @@
  * Created by sww on 2016/10/21.
  */
 
-import React, { Component,PropTypes} from 'react';
+import React, { Component} from 'react';
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   Text,

--- a/lib/SwRefreshListView.ios.js
+++ b/lib/SwRefreshListView.ios.js
@@ -1,7 +1,8 @@
 /**
  * Created by sww on 2016/10/21.
  */
-import React, { Component,PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   Text,

--- a/lib/SwRefreshScrollView.android.js
+++ b/lib/SwRefreshScrollView.android.js
@@ -1,7 +1,8 @@
 /**
  * Created by sww on 2016/10/21.
  */
-import React, { Component,PropTypes} from 'react';
+import React, { Component} from 'react';
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   Text,

--- a/lib/SwRefreshScrollView.ios.js
+++ b/lib/SwRefreshScrollView.ios.js
@@ -2,7 +2,8 @@
  * Created by sww on 2016/10/21.
  */
 
-import React, { Component,PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   Text,


### PR DESCRIPTION
Prop types are a feature for runtime validation of props during development. We've extracted the built-in prop types to a separate package to reflect the fact that not everybody uses them.

In 15.5, instead of accessing PropTypes from the main React object, install the prop-types package and import them from there: